### PR TITLE
Allow web installer to download release ZIPs

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -143,6 +143,7 @@ http {
             root /var/www/releases;
             include /etc/nginx/snippets/security-headers.conf;
             add_header Cache-Control "public, max-age=31536000, immutable";
+            add_header Access-Control-Allow-Origin "https://grapheneos.org";
         }
 
         location ~ "\.(br|gz)$" {


### PR DESCRIPTION
This allows the web installer on grapheneos.org to download factory image ZIPs for flashing.

See also: https://github.com/GrapheneOS/grapheneos.org/pull/159