### PR TITLE
Fix release deploy logging and nginx URI matchers

### DIFF
--- a/deploy-releases
+++ b/deploy-releases
@@ -19,5 +19,5 @@ zopfli overview.json
 rsync -c overview.json{,.br,.gz} releases/
 rm overview.json overview.json.br overview.json.gz
 
-parallel "rsync -rptv --chmod=D755,F644 --progress --delete --fsync --preallocate releases/ {}:/srv/releases 2>&1 >logs/{}.log" ::: ${servers[@]}
+parallel "rsync -rptv --chmod=D755,F644 --progress --delete --fsync --preallocate releases/ {}:/srv/releases >logs/{}.log 2>&1" ::: ${servers[@]}
 tail -n +1 logs/*.log

--- a/nginx/releases.conf
+++ b/nginx/releases.conf
@@ -212,7 +212,7 @@ server {
     include security-headers-releases.conf;
     add_header Cache-Control "public";
 
-    if ($request_uri ~ ^[^?]+//) {
+    if ($request_uri ~ ^[^?]*//) {
         rewrite ^(.*)$ $1 permanent;
     }
 
@@ -271,7 +271,7 @@ server {
         add_header Cache-Control "public";
         add_header X-Robots-Tag "none" always;
 
-        location ~ \.(:?apk|apk\.idsig)$ {
+        location ~ \.(?:apk|apk\.idsig)$ {
             include security-headers-releases.conf;
             add_header Cache-Control "public, max-age=31536000, immutable";
             add_header X-Robots-Tag "none" always;
@@ -279,7 +279,7 @@ server {
             brotli_static on;
         }
 
-        location ~ \.(:?apk\.br|apk\.gz|fsv_sig)$ {
+        location ~ \.(?:apk\.br|apk\.gz|fsv_sig)$ {
             include security-headers-releases.conf;
             add_header Cache-Control "public, max-age=31536000, immutable";
             add_header X-Robots-Tag "none" always;


### PR DESCRIPTION
This PR fixes three potential issues :

First, it corrects the redirection order in the release deployment script so `rsync` stderr is captured in the per-server log files instead of leaking to the terminal. That makes deployment logs complete and ensures failures are visible in the logged output.

Second, it fixes two nginx regexes for app package paths that were using `(:?...)` instead of the intended non-capturing group syntax `(?:...)`. The old patterns could match malformed extension variants and were not expressing the intended URI matching behavior.

Third, it aligns duplicate-slash URI canonicalization on `apps.grapheneos.org` with the existing `releases.grapheneos.org` behavior so requests beginning with `//` are normalized consistently.